### PR TITLE
feat(e2e): Add test for TCP tunneling to Google DNS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,11 @@ run-client: build
 
 .PHONY: e2e
 e2e: build
+	./tests/e2e/test_close_server_gracefully.sh
 	./tests/e2e/test_basic_tcp.sh
 	./tests/e2e/test_tcp_local_server_not_start.sh
-	./tests/e2e/test_close_server_gracefully.sh
 	./tests/e2e/test_tcp_with_tunnel_http_server.sh
+	./tests/e2e/test_tcp_tunnel_to_google_dns.sh
 	./tests/e2e/test_http_tunnel_with_domain.sh
 	./tests/e2e/test_http_tunnel_with_subdomain.sh
 	./tests/e2e/test_http_tunnel_with_given_port.sh

--- a/tests/e2e/test_tcp_tunnel_to_google_dns.sh
+++ b/tests/e2e/test_tcp_tunnel_to_google_dns.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# set -x
+
+root_dir=$(git rev-parse --show-toplevel)
+cur_dir=$root_dir/tests/e2e
+source $cur_dir/util.sh
+
+cleanup() {
+  echo "Cleaning up..."
+  kill -SIGINT $server_pid
+  kill -SIGINT $client_pid
+}
+
+trap cleanup EXIT
+
+exec ./target/debug/tunneld &
+server_pid=$!
+wait_port 6610
+
+exec ./target/debug/tunnel tcp 53 --remote-port 10053 --local-addr 8.8.8.8 &
+client_pid=$!
+wait_port 10053
+
+output=$(dig @127.0.0.1 -p 10053 +tcp +noedns google.com)
+if echo "$output" | grep -q "ANSWER SECTION"; then
+    echo "Test passed: ANSWER SECTION found in dig output"
+else
+    echo "Test failed: ANSWER SECTION not found in dig output"
+    echo "Output:"
+    echo "$output"
+    exit 1
+fi


### PR DESCRIPTION
This commit adds a new test script `test_tcp_tunnel_to_google_dns.sh` to the `e2e` test suite. The script sets up a TCP tunnel to Google DNS using the `tunnel` binary and verifies the successful resolution of a domain name using `dig`. This test ensures that the TCP tunneling functionality is working correctly and that DNS lookup is functioning as expected.

Note: This commit message is based on the analysis of the code changes and recent repository commits.