### PR TITLE
feat: Update logging setup to use debug module instead of otel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ FEATURES =
 
 ifeq ($(ENABLE_TOKIO_CONSOLE), 1)
 	RUSTFLAGS +="--cfg tokio_unstable"
-	FEATURES += "otel"
+	FEATURES += "debug"
 endif
 
 .PHONY: build

--- a/tunneld-client/src/bin/main.rs
+++ b/tunneld-client/src/bin/main.rs
@@ -7,7 +7,7 @@ use tunneld_client::{
     tunnel::{new_http_tunnel, new_tcp_tunnel, new_udp_tunnel},
     TunnelFuture,
 };
-use tunneld_pkg::{otel::setup_logging, shutdown};
+use tunneld_pkg::{debug::setup_logging, shutdown};
 
 #[derive(Parser)]
 struct Args {

--- a/tunneld-pkg/Cargo.toml
+++ b/tunneld-pkg/Cargo.toml
@@ -17,4 +17,4 @@ futures = "0.3.30"
 bytes = "1.6.0"
 
 [features]
-otel=[]
+debug=[]

--- a/tunneld-pkg/src/debug.rs
+++ b/tunneld-pkg/src/debug.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "otel")]
+#[cfg(feature = "debug")]
 pub fn setup_logging(default_console_port: u16) {
     use std::net::Ipv4Addr;
     use tracing_subscriber::prelude::*;
@@ -17,7 +17,7 @@ pub fn setup_logging(default_console_port: u16) {
         .init();
 }
 
-#[cfg(not(feature = "otel"))]
+#[cfg(not(feature = "debug"))]
 pub fn setup_logging(_: u16) {
     tracing_subscriber::fmt::init();
 }

--- a/tunneld-pkg/src/lib.rs
+++ b/tunneld-pkg/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod bridge;
+pub mod debug;
 pub mod event;
 pub mod io;
-pub mod otel;
 pub mod shutdown;
 pub mod util;

--- a/tunneld-server/src/bin/main.rs
+++ b/tunneld-server/src/bin/main.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use tokio::signal;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
-use tunneld_pkg::otel::setup_logging;
+use tunneld_pkg::debug::setup_logging;
 use tunneld_server::{Config, Server};
 
 #[derive(Parser, Debug, Default)]


### PR DESCRIPTION
This commit updates the logging setup in the codebase to use the debug module instead of the otel module. The necessary changes have been made in the `main.rs` files of both the client and server components, as well as in the `Cargo.toml` file. This change aligns the codebase with the recent updates and ensures consistent logging behavior.
